### PR TITLE
Stash 'dist_auth', a normalized "from:auth_id" string

### DIFF
--- a/templates/dist/dist.html.ep
+++ b/templates/dist/dist.html.ep
@@ -9,7 +9,7 @@
 % end
 
 <h2><%= $dist->{name} %>
-  <small><%= $dist->{dist_source} %>:<%= $dist->{author_id} %>
+  <small><%= stash 'dist_auth' %>
     <a href="<%= $dist->{url} %>" class="btn btn-sm btn-default"
       title="Dist source" data-toggle="tooltip"
     ><i class="source-<%= $dist->{dist_source} %>"></i></a>


### PR DESCRIPTION
This cleans up the display of from:zef modules, which previously are
displayed as "Nifty::Module zef:zef:clever-user".

Sensibly, the META6.json "auth" field often (should?) contains the
source prefix in it, like "auth": "zef:some-user". But not always; the
CPAN modules have "auth" injected as just the PAUSE id, for example.
So the best we can do here is strip the source prefix if it is an
exact match.