### PR TITLE
Remove PODRenderer plugin, it's no longer in Mojolicious

### DIFF
--- a/lib/ModulesPerl6.pm
+++ b/lib/ModulesPerl6.pm
@@ -19,7 +19,8 @@ sub startup {
     # SETUP
     $self->plugin('Config');
     $self->moniker('ModulesPerl6');
-    $self->plugin('PODRenderer') if $self->mode eq 'development';
+    # TODO PODRenderer is no longer part of Mojolicious; switch to PODViewer
+    #$self->plugin('PODRenderer') if $self->mode eq 'development';
     unshift $self->static->paths->@*, $ENV{MODULESPERL6_EXTRA_STATIC_PATH}
         if length $ENV{MODULESPERL6_EXTRA_STATIC_PATH};
 


### PR DESCRIPTION
Mojolicious::Plugin::PODViewer is a community-maintained replacement,
which would be appropriate to use once a current Mojolicious version can
be used (see #115).